### PR TITLE
Default snapshot dir

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ It could be re-written using snapshot testing as:
 .. code-block:: python
 
     def test_function_output_with_snapshot(snapshot):
-        snapshot.snapshot_dir = 'snapshots'
+        snapshot.snapshot_dir = 'snapshots'  # This line is optional.
         snapshot.assert_match(foo('function input'), 'foo_output.txt')
 
 The author of the test should then

--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -20,7 +20,7 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     text_type = str
 else:
-    text_type = unicode
+    text_type = unicode  # noqa: F821
 
 
 def pytest_addoption(parser):

--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from pathlib2 import Path
 
-PARAMETRIZED_TEST_REGEX = re.compile('^.*\[(.*)\]$')
+PARAMETRIZED_TEST_REGEX = re.compile(r'^.*?\[(.*)\]$')
 
 def pytest_addoption(parser):
     group = parser.getgroup('snapshot')
@@ -229,7 +229,17 @@ def get_default_snapshot_dir(node):
         parametrize_match = PARAMETRIZED_TEST_REGEX.match(node.name)
         assert parametrize_match is not None, 'Expected request.node.name to be of format TEST_FUNCTION[PARAMS]'
         parametrize_name = PARAMETRIZED_TEST_REGEX.match(node.name).group(1)
+        parametrize_name = get_valid_filename(parametrize_name)
     default_snapshot_dir = test_module_dir.join('snapshots', test_module, test_name)
     if parametrize_name:
         default_snapshot_dir = default_snapshot_dir.join(parametrize_name)
     return Path(str(default_snapshot_dir))
+
+
+def get_valid_filename(s):
+    """
+    Return the given string converted to a string that can be used for a clean filename.
+    Taken from https://github.com/django/django/blob/master/django/utils/text.py
+    """
+    s = str(s).strip().replace(' ', '_')
+    return re.sub(r'(?u)[^-\w.]', '', s)

--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import re
+import sys
 
 import pytest
 from packaging import version
@@ -12,6 +13,15 @@ except ImportError:
     from pathlib2 import Path
 
 PARAMETRIZED_TEST_REGEX = re.compile(r'^.*?\[(.*)\]$')
+
+# Taken from six.
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
+
 
 def pytest_addoption(parser):
     group = parser.getgroup('snapshot')
@@ -120,6 +130,9 @@ class Snapshot(object):
         :type value: str
         :type snapshot_name: str or Path
         """
+        if not isinstance(value, text_type):
+            raise TypeError('value must be {}'.format(text_type.__name__))
+
         snapshot_path = self._snapshot_path(snapshot_name)
 
         if snapshot_path.is_file():

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=[
         'packaging',
+        'pathlib2>=2.2.0;python_version<"3.6"',  # identical to pytest's setup.py
         'pytest>=3.0.0',
         'typing',
     ],

--- a/tests/test_assert_match.py
+++ b/tests/test_assert_match.py
@@ -10,37 +10,6 @@ def basic_case_dir(testdir):
     return case_dir
 
 
-def test_assert_match_without_setting_snapshot_dir(testdir, basic_case_dir):
-    testdir.makepyfile("""
-        def test_sth(snapshot):
-            snapshot.assert_match(u'the value of snapshot1.txt', 'snapshot1.txt')
-    """)
-    result = testdir.runpytest('-v')
-    result.stdout.fnmatch_lines([
-        '*::test_sth FAILED*',
-        "E* AssertionError: snapshot.snapshot_dir was not set.",
-    ])
-    assert result.ret == 1
-
-
-def test_assert_match_auto_setting_snapshot_dir(testdir, basic_case_dir):
-    """
-    Test that when using paths as snapshot names,
-    if the snapshot_dir is not already set, it is set to the snapshot's parent.
-    """
-    testdir.makepyfile("""
-        try:
-            from pathlib import Path
-        except ImportError:
-            from pathlib2 import Path
-
-        def test_sth(snapshot):
-            snapshot.assert_match(u'the value of snapshot1.txt', Path('case_dir/snapshot1.txt'))
-            assert snapshot.snapshot_dir == Path('case_dir').absolute()
-    """)
-    assert_pytest_passes(testdir)
-
-
 def test_assert_match_with_external_snapshot_path(testdir, basic_case_dir):
     testdir.makepyfile("""
         try:
@@ -180,6 +149,27 @@ def test_assert_match_create_new_snapshot(testdir, basic_case_dir):
         'E*     sub_dir*new_snapshot1.txt',
     ])
     assert result.ret == 1
+
+    assert_pytest_passes(testdir)  # assert that snapshot update worked
+
+
+def test_assert_match_create_new_snapshot_in_default_dir(testdir):
+    testdir.makepyfile("""
+        def test_sth(snapshot):
+            snapshot.assert_match(u'the value of new_snapshot1.txt', 'sub_dir/new_snapshot1.txt')
+    """)
+    result = testdir.runpytest('-v', '--snapshot-update')
+    result.stdout.fnmatch_lines([
+        '*::test_sth PASSED*',
+        '*::test_sth ERROR*',
+        "E* Snapshot directory was modified: snapshots?test_assert_match_create_new_snapshot_in_default_dir?test_sth",
+        'E*   Created snapshots:',
+        'E*     sub_dir?new_snapshot1.txt',
+    ])
+    assert result.ret == 1
+    assert testdir.tmpdir.join(
+        'snapshots/test_assert_match_create_new_snapshot_in_default_dir/test_sth/sub_dir/new_snapshot1.txt'
+    ).read_text('utf-8') == u'the value of new_snapshot1.txt'
 
     assert_pytest_passes(testdir)  # assert that snapshot update worked
 

--- a/tests/test_assert_match.py
+++ b/tests/test_assert_match.py
@@ -24,7 +24,7 @@ def test_assert_match_with_external_snapshot_path(testdir, basic_case_dir):
     result = testdir.runpytest('-v')
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
-        "E* AssertionError: Snapshot path not_case_dir*snapshot1.txt is not in case_dir",
+        "E* AssertionError: Snapshot path not_case_dir?snapshot1.txt is not in case_dir",
     ])
     assert result.ret == 1
 
@@ -48,7 +48,7 @@ def test_assert_match_failure(testdir, basic_case_dir):
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
         ">* raise AssertionError(snapshot_diff_msg)",
-        'E* AssertionError: value does not match the expected value in snapshot case_dir*snapshot1.txt',
+        'E* AssertionError: value does not match the expected value in snapshot case_dir?snapshot1.txt',
         "E* assert * == *",
         "E* - the value of snapshot1.txt",
         "E* + the INCORRECT value of snapshot1.txt",
@@ -66,7 +66,7 @@ def test_assert_match_missing_snapshot(testdir, basic_case_dir):
     result = testdir.runpytest('-v')
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
-        "E* snapshot case_dir*snapshot_that_doesnt_exist.txt doesn't exist. "
+        "E* snapshot case_dir?snapshot_that_doesnt_exist.txt doesn't exist. "
         "(run pytest with --snapshot-update to create it)",
     ])
     assert result.ret == 1
@@ -146,7 +146,7 @@ def test_assert_match_create_new_snapshot(testdir, basic_case_dir):
         '*::test_sth ERROR*',
         "E* Snapshot directory was modified: case_dir",
         'E*   Created snapshots:',
-        'E*     sub_dir*new_snapshot1.txt',
+        'E*     sub_dir?new_snapshot1.txt',
     ])
     assert result.ret == 1
 
@@ -184,6 +184,6 @@ def test_assert_match_existing_snapshot_is_not_file(testdir, basic_case_dir):
     result = testdir.runpytest('-v', '--snapshot-update')
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
-        "E* AssertionError: snapshot exists but is not a file: case_dir*directory1",
+        "E* AssertionError: snapshot exists but is not a file: case_dir?directory1",
     ])
     assert result.ret == 1

--- a/tests/test_assert_match_dir.py
+++ b/tests/test_assert_match_dir.py
@@ -37,7 +37,7 @@ def test_assert_match_dir_failure(testdir, basic_case_dir):
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
         ">* raise AssertionError(snapshot_diff_msg)",
-        'E* AssertionError: value does not match the expected value in snapshot case_dir*dict_snapshot1*obj2.txt',
+        'E* AssertionError: value does not match the expected value in snapshot case_dir?dict_snapshot1?obj2.txt',
         "E* assert * == *",
         "E* - the value of obj2.txt",
         "E* + the INCORRECT value of obj2.txt",
@@ -59,7 +59,7 @@ def test_assert_match_dir_missing_snapshot(testdir, basic_case_dir):
     result = testdir.runpytest('-v')
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
-        "E* AssertionError: Values do not match snapshots in case_dir*dict_snapshot1",
+        "E* AssertionError: Values do not match snapshots in case_dir?dict_snapshot1",
         'E*   Values without snapshots:',
         'E*     new_obj.txt',
         'E*   Run pytest with --snapshot-update to update the snapshot directory.',
@@ -78,7 +78,7 @@ def test_assert_match_dir_missing_value(testdir, basic_case_dir):
     result = testdir.runpytest('-v')
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
-        "E* AssertionError: Values do not match snapshots in case_dir*dict_snapshot1",
+        "E* AssertionError: Values do not match snapshots in case_dir?dict_snapshot1",
         'E*   Snapshots without values:',
         'E*     obj2.txt',
         'E*   Run pytest with --snapshot-update to update the snapshot directory.',
@@ -145,7 +145,7 @@ def test_assert_match_dir_update_existing_snapshot(testdir, basic_case_dir, case
         '*::test_sth ERROR*',
         "E* AssertionError: Snapshot directory was modified: case_dir",
         'E*   Updated snapshots:',
-        'E*     dict_snapshot1*obj2.txt',
+        'E*     dict_snapshot1?obj2.txt',
     ])
     assert result.ret == 1
 
@@ -168,7 +168,7 @@ def test_assert_match_dir_create_new_snapshot_file(testdir, basic_case_dir):
         '*::test_sth ERROR*',
         "E* AssertionError: Snapshot directory was modified: case_dir",
         'E*   Created snapshots:',
-        'E*     dict_snapshot1*new_obj.txt',
+        'E*     dict_snapshot1?new_obj.txt',
     ])
     assert result.ret == 1
 
@@ -189,7 +189,7 @@ def test_assert_match_dir_delete_snapshot_file(testdir, basic_case_dir):
         '*::test_sth ERROR*',
         "E* AssertionError: Snapshot directory was modified: case_dir",
         'E*   Snapshots that should be deleted: (run pytest with --allow-snapshot-deletion to delete them)',
-        'E*     dict_snapshot1*obj2.txt',
+        'E*     dict_snapshot1?obj2.txt',
     ])
     assert result.ret == 1
 
@@ -199,7 +199,7 @@ def test_assert_match_dir_delete_snapshot_file(testdir, basic_case_dir):
         '*::test_sth ERROR*',
         'E* AssertionError: Snapshot directory was modified: case_dir',
         'E*   Deleted snapshots:',
-        'E*     dict_snapshot1*obj2.txt',
+        'E*     dict_snapshot1?obj2.txt',
     ])
     assert result.ret == 1
 
@@ -220,7 +220,7 @@ def test_assert_match_dir_create_new_snapshot_dir(testdir, basic_case_dir):
         '*::test_sth ERROR*',
         'E* AssertionError: Snapshot directory was modified: case_dir',
         'E*   Created snapshots:',
-        'E*     new_dict_snapshot*obj1.txt',
+        'E*     new_dict_snapshot?obj1.txt',
     ])
     assert result.ret == 1
 
@@ -237,6 +237,6 @@ def test_assert_match_dir_existing_snapshot_is_not_dir(testdir, basic_case_dir):
     result = testdir.runpytest('-v', '--snapshot-update')
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
-        "E* AssertionError: snapshot exists but is not a directory: case_dir*file1",
+        "E* AssertionError: snapshot exists but is not a directory: case_dir?file1",
     ])
     assert result.ret == 1

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,6 +1,44 @@
+from tests.utils import assert_pytest_passes
+
+
 def test_help_message(testdir):
     result = testdir.runpytest('--help')
     result.stdout.fnmatch_lines([
         'snapshot:',
         '*--snapshot-update*Update snapshots.',
     ])
+
+
+def test_default_snapshot_dir_without_parametrize(testdir):
+    testdir.makepyfile("""
+        try:
+            from pathlib import Path
+        except ImportError:
+            from pathlib2 import Path
+
+        def test_sth(snapshot):
+            assert snapshot.snapshot_dir == \
+                Path('snapshots/test_default_snapshot_dir_without_parametrize/test_sth').absolute()
+    """)
+    assert_pytest_passes(testdir)
+
+
+def test_default_snapshot_dir_with_parametrize(testdir):
+    testdir.makepyfile("""
+        import pytest
+        try:
+            from pathlib import Path
+        except ImportError:
+            from pathlib2 import Path
+
+        @pytest.mark.parametrize('param', ['a', 'b'])
+        def test_sth(snapshot, param):
+            assert snapshot.snapshot_dir == \
+                Path('snapshots/test_default_snapshot_dir_with_parametrize/test_sth/{}'.format(param)).absolute()
+    """)
+    result = testdir.runpytest('-v')
+    result.stdout.fnmatch_lines([
+        '*::test_sth?a? PASSED*',
+        '*::test_sth?b? PASSED*',
+    ])
+    assert result.ret == 0


### PR DESCRIPTION
Add a default snapshot_dir.

If `test_module.py::test_func` creates a snapshot without setting `snapshot_dir` beforehand, a default snapshot directory will be used alongside `test_module.py` in the path `snapshots/test_module/test_func`.

Closes #12 