### PR TITLE
Bytes snapshots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ This `pytest`_ plugin was generated with `Cookiecutter`_ along with `@hackebrot`
 Features
 --------
 
-* snapshot testing of strings
-* snapshot testing of collections of strings
+* snapshot testing of strings ands bytes
+* snapshot testing of collections of strings and bytes
 * the user has complete control over the snapshot file path and content
 
 
@@ -102,8 +102,8 @@ In the second example, the developer would simply
 2. verify that the snapshot file contains the new expected result
 3. commit it to version control.
 
-Snapshot testing can be used for expressions whose values are strings.
-For other types, you should first create a *human readable* textual representation of the value.
+Snapshot testing can be used for expressions whose values are strings or bytes.
+For other types, you should first create a *human readable* representation of the value.
 For example, to snapshot test a *json-serializable* value, you could either convert it into json
 or preferably convert it into the more readable yaml format using `PyYAML`_:
 
@@ -114,7 +114,7 @@ or preferably convert it into the more readable yaml format using `PyYAML`_:
 assert_match_dir
 ================
 When snapshot testing a *collection* of values, ``assert_match_dir`` comes in handy.
-It will save a snapshot of a collection as a directory containing snapshot files.
+It will save a snapshot of a collection of values as a directory of snapshot files.
 ``assert_match_dir`` takes a mapping from file name to value.
 
 For example, the following code creates the directory ``snapshots/people``

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Features
 Requirements
 ------------
 
-* Python 2.7 or 3.5+ or `PyPy`_
+* Python 3.5+ or `PyPy`_
 * `pytest`_ 3.0+
 
 

--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -35,7 +35,7 @@ def snapshot(request):
         yield snapshot
 
 
-def _assert_equal(value, expected_value):
+def _assert_equal(value, expected_value) -> None:
     # pytest diffs before version 5.4.0 required expected to be on the left hand side.
     expected_on_right = version.parse(pytest.__version__) >= version.parse("5.4.0")
     if expected_on_right:
@@ -131,7 +131,7 @@ class Snapshot:
         Asserts that ``value`` equals the current value of the snapshot with the given ``snapshot_name``.
 
         If pytest was run with the --snapshot-update flag, the snapshot will instead be updated to ``value``.
-        The test will fail if the value changed.
+        The test will fail if there were any changes to the snapshot.
         """
         compare, encode, decode = self._get_compare_encode_decode(value)
         snapshot_path = self._snapshot_path(snapshot_name)
@@ -178,7 +178,7 @@ class Snapshot:
         Asserts that the values in values_by_filename equal the current values in the given snapshot directory.
 
         If pytest was run with the --snapshot-update flag, the snapshots will instead be updated.
-        The test will fail there were any changes to the snapshots.
+        The test will fail if there were any changes to the snapshots.
         """
         snapshot_dir_path = self._snapshot_path(snapshot_dir_name)
 

--- a/tests/test_assert_match.py
+++ b/tests/test_assert_match.py
@@ -26,11 +26,20 @@ def test_assert_match_with_external_snapshot_path(testdir, basic_case_dir):
     assert result.ret == 1
 
 
-def test_assert_match_success(testdir, basic_case_dir):
+def test_assert_match_success_string(testdir, basic_case_dir):
     testdir.makepyfile("""
         def test_sth(snapshot):
             snapshot.snapshot_dir = 'case_dir'
             snapshot.assert_match('the valuÉ of snapshot1.txt', 'snapshot1.txt')
+    """)
+    assert_pytest_passes(testdir)
+
+
+def test_assert_match_success_bytes(testdir, basic_case_dir):
+    testdir.makepyfile(r"""
+        def test_sth(snapshot):
+            snapshot.snapshot_dir = 'case_dir'
+            snapshot.assert_match(b'the valu\xc3\x89 of snapshot1.txt', 'snapshot1.txt')
     """)
     assert_pytest_passes(testdir)
 

--- a/tests/test_assert_match.py
+++ b/tests/test_assert_match.py
@@ -35,7 +35,7 @@ def test_assert_match_success(testdir, basic_case_dir):
     assert_pytest_passes(testdir)
 
 
-def test_assert_match_failure(testdir, basic_case_dir):
+def test_assert_match_failure_string(testdir, basic_case_dir):
     testdir.makepyfile("""
         def test_sth(snapshot):
             snapshot.snapshot_dir = 'case_dir'
@@ -55,16 +55,36 @@ def test_assert_match_failure(testdir, basic_case_dir):
     assert result.ret == 1
 
 
+def test_assert_match_failure_bytes(testdir, basic_case_dir):
+    testdir.makepyfile("""
+        def test_sth(snapshot):
+            snapshot.snapshot_dir = 'case_dir'
+            snapshot.assert_match(b'the INCORRECT value of snapshot1.txt', 'snapshot1.txt')
+    """)
+    result = testdir.runpytest('-v')
+    result.stdout.fnmatch_lines([
+        r'*::test_sth FAILED*',
+        r">* raise AssertionError(snapshot_diff_msg)",
+        r'E* AssertionError: value does not match the expected value in snapshot case_dir?snapshot1.txt',
+        r"E* assert * == *",
+        r"E* At index 4 diff: * != *",
+        r"E* Full diff:",
+        r"E* - b'the valu\xc3\x89 of snapshot1.txt'",
+        r"E* + b'the INCORRECT value of snapshot1.txt'",
+    ])
+    assert result.ret == 1
+
+
 def test_assert_match_invalid_type(testdir, basic_case_dir):
     testdir.makepyfile("""
         def test_sth(snapshot):
             snapshot.snapshot_dir = 'case_dir'
-            snapshot.assert_match(b'incorrect typed obj', 'snapshot1.txt')
+            snapshot.assert_match(123, 'snapshot1.txt')
     """)
     result = testdir.runpytest('-v')
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
-        'E* TypeError: value must be str',
+        'E* TypeError: value must be str or bytes',
     ])
     assert result.ret == 1
 


### PR DESCRIPTION
Adds support for snapshot testing `bytes` values.

This was described in #29.