### PR TITLE
Test --assert=plain behaviour and fix related bug.

### DIFF
--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -188,7 +188,7 @@ class Snapshot:
                 else:
                     snapshot_diff_msg = None
 
-                if snapshot_diff_msg:
+                if snapshot_diff_msg is not None:
                     snapshot_diff_msg = 'value does not match the expected value in snapshot {}\n{}'.format(
                         shorten_path(snapshot_path), snapshot_diff_msg)
                     raise AssertionError(snapshot_diff_msg)
@@ -255,6 +255,6 @@ def _get_default_snapshot_dir(node: _pytest.python.Function) -> Path:
         parametrize_name = parametrize_match.group(1)
         parametrize_name = get_valid_filename(parametrize_name)
     default_snapshot_dir = test_module_dir.join('snapshots', test_module, test_name)
-    if parametrize_name:
+    if parametrize_name is not None:
         default_snapshot_dir = default_snapshot_dir.join(parametrize_name)
     return Path(str(default_snapshot_dir))

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
 envlist =
-    # Pytest <6 doesn't work on Python >=3.10
+    # Pytest <6.2.5 not supported on Python >=3.10
     py{36,37,38,39}-pytest{3,4,5}-coverage
     py{35,36,37,38,39,310,3}-pytest{6,}-coverage
     # Coverage is slow in pypy


### PR DESCRIPTION
This fixes the bug mentioned in #49.
The bug is that when running pytest --assert=plain, the tests would still pass even if the tested value did not equal the snapshot.