### PR TITLE
Specify --assert=plain/rewrite for tests.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,7 +202,8 @@ Contributing
 Contributions are very welcome. Before contributing, please discuss the change with me.
 I wish to keep this plugin flexible and not enforce any project layout on the user.
 
-Tests can be run with `tox`_.
+Tests can be run with `tox`_ or ``python -m pytest``.
+Note that the test suite does not pass when run with ``--assert=plain``.
 
 
 License

--- a/tests/test_assert_match_dir.py
+++ b/tests/test_assert_match_dir.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from tests.utils import assert_pytest_passes
+from tests.utils import assert_pytest_passes, runpytest_with_assert_mode
 
 
 @pytest.fixture
@@ -29,7 +29,7 @@ def test_assert_match_dir_success(testdir, basic_case_dir):
     assert_pytest_passes(testdir)
 
 
-def test_assert_match_dir_failure(testdir, basic_case_dir):
+def test_assert_match_dir_failure(request, testdir, basic_case_dir):
     testdir.makepyfile("""
         def test_sth(snapshot):
             snapshot.snapshot_dir = 'case_dir'
@@ -40,7 +40,7 @@ def test_assert_match_dir_failure(testdir, basic_case_dir):
                 },
             }, 'dict_snapshot1')
     """)
-    result = testdir.runpytest('-v')
+    result = runpytest_with_assert_mode(testdir, request, '-v', '--assert=rewrite')
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
         ">* raise AssertionError(snapshot_diff_msg)",
@@ -280,7 +280,6 @@ def test_assert_match_dir_empty_snapshot(testdir, basic_case_dir):
     When testing a empty dict, if the directory doesn't exist, the correct behaviour is to pass.
     This behaviour is important since git ignores empty directories.
     """
-    basic_case_dir.join('file1').write_text('', 'ascii')
     testdir.makepyfile("""
         def test_sth(snapshot):
             snapshot.snapshot_dir = 'case_dir'

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,10 +1,12 @@
+import sys
 from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 
 from pytest_snapshot._utils import shorten_path, might_be_valid_filename, simple_version_parse, \
     _pytest_expected_on_right, flatten_dict, flatten_filesystem_dict
-from tests.utils import assert_pytest_passes
+from tests.utils import assert_pytest_passes, runpytest_with_assert_mode
 
 from pathlib import Path
 
@@ -154,3 +156,18 @@ def test_flatten_filesystem_dict_illegal_filename(illegal_filename):
         flatten_filesystem_dict({
             illegal_filename: 'contents'
         })
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="assert_called_once doesn't exist in Python <3.6")
+def test_runpytest_with_assert_mode(request):
+    testdir = Mock()
+    runpytest_with_assert_mode(testdir, request, '--assert=plain')
+    runpytest_with_assert_mode(testdir, request, '--assert=rewrite')
+    testdir.runpytest.assert_called_once()
+    testdir.runpytest_subprocess.assert_called_once()
+
+
+def test_runpytest_with_assert_mode_without_assert_mode(request):
+    testdir = Mock()
+    with pytest.raises(ValueError):
+        runpytest_with_assert_mode(testdir, request)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,26 @@
+def runpytest_with_assert_mode(testdir, request, *args):
+    """
+    Calls `runpytest` if possible, otherwise calls `runpytest_subprocess`.
+
+    Calling `runpytest` when the caller is run with --assert=rewrite and the callee is run with --assert=plain
+    or vice versa does not work correctly, so this wrapper calls `runpytest_subprocess` in these cases.
+
+    Note: If you are trying to debug a test that reaches `runpytest_subprocess`, consider running the test with another
+    --assert mode.
+    """
+    if '--assert=plain' in args:
+        assert_mode = 'plain'
+    elif '--assert=rewrite' in args:
+        assert_mode = 'rewrite'
+    else:
+        raise ValueError('Use this function only if you require --assert=rewrite or --assert=plain')
+
+    if assert_mode == request.config.option.assertmode:
+        return testdir.runpytest(*args)
+    else:
+        return testdir.runpytest_subprocess(*args)
+
+
 def assert_pytest_passes(testdir):
     result = testdir.runpytest('-v')
     result.stdout.fnmatch_lines(['*::test_sth PASSED*'])


### PR DESCRIPTION
Test with both --assert=rewrite and --assert=plain.
This should help catch bugs such as #49.