### PR TITLE
Improve error messages for users unfamiliar with the library.

### DIFF
--- a/tests/test_assert_match.py
+++ b/tests/test_assert_match.py
@@ -61,6 +61,7 @@ def test_assert_match_failure_string(request, testdir, basic_case_dir):
         '*::test_sth FAILED*',
         r">* snapshot.assert_match('the INCORRECT value of snapshot1.txt\n', 'snapshot1.txt')",
         'E* AssertionError: value does not match the expected value in snapshot case_dir?snapshot1.txt',
+        "E*   (run pytest with --snapshot-update to update snapshots)",
         "E* assert * == *",
         "E* - the valuÉ of snapshot1.txt",
         "E* ?         ^",
@@ -82,6 +83,7 @@ def test_assert_match_failure_bytes(request, testdir, basic_case_dir):
         r'*::test_sth FAILED*',
         r">* snapshot.assert_match(b'the INCORRECT value of snapshot1.txt' + os.linesep.encode(), 'snapshot1.txt')",
         r'E* AssertionError: value does not match the expected value in snapshot case_dir?snapshot1.txt',
+        r'E*   (run pytest with --snapshot-update to update snapshots)',
         r"E* assert * == *",
         r"E* At index 4 diff: * != *",
         r"E* Full diff:",
@@ -114,6 +116,7 @@ def test_assert_match_failure_assert_plain(request, testdir, basic_case_dir):
     result.stdout.fnmatch_lines([
         r">* snapshot.assert_match('the INCORRECT value of snapshot1.txt\n', 'snapshot1.txt')",
         'E* AssertionError: value does not match the expected value in snapshot case_dir?snapshot1.txt',
+        'E*   (run pytest with --snapshot-update to update snapshots)',
         '',
         '*test_assert_match_failure_assert_plain.py:*: AssertionError',
     ], consecutive=True)
@@ -200,7 +203,8 @@ def test_assert_match_update_existing_snapshot(testdir, basic_case_dir, case_dir
         '*::test_sth PASSED*',
         '*::test_sth ERROR*',
         '* ERROR at teardown of test_sth *',
-        "Snapshot directory was modified: case_dir",
+        'Snapshot directory was modified: case_dir',
+        '  (verify that the changes are expected before committing them to version control)',
         '  Updated snapshots:',
         '    snapshot1.txt',
     ])
@@ -227,7 +231,8 @@ def test_assert_match_update_existing_snapshot_and_exception_in_test(testdir, ba
         '*::test_sth FAILED*',
         '*::test_sth ERROR*',
         '* ERROR at teardown of test_sth *',
-        "Snapshot directory was modified: case_dir",
+        'Snapshot directory was modified: case_dir',
+        '  (verify that the changes are expected before committing them to version control)',
         '  Updated snapshots:',
         '    snapshot1.txt',
         'E* assert False',
@@ -246,7 +251,8 @@ def test_assert_match_create_new_snapshot(testdir, basic_case_dir):
         '*::test_sth PASSED*',
         '*::test_sth ERROR*',
         '* ERROR at teardown of test_sth *',
-        "Snapshot directory was modified: case_dir",
+        'Snapshot directory was modified: case_dir',
+        '  (verify that the changes are expected before committing them to version control)',
         '  Created snapshots:',
         '    sub_dir?new_snapshot1.txt',
     ])
@@ -265,7 +271,8 @@ def test_assert_match_create_new_snapshot_in_default_dir(testdir):
         '*::test_sth PASSED*',
         '*::test_sth ERROR*',
         '* ERROR at teardown of test_sth *',
-        "Snapshot directory was modified: snapshots?test_assert_match_create_new_snapshot_in_default_dir?test_sth",
+        'Snapshot directory was modified: snapshots?test_assert_match_create_new_snapshot_in_default_dir?test_sth',
+        '  (verify that the changes are expected before committing them to version control)',
         '  Created snapshots:',
         '    sub_dir?new_snapshot1.txt',
     ])

--- a/tests/test_assert_match_dir.py
+++ b/tests/test_assert_match_dir.py
@@ -50,6 +50,7 @@ def test_assert_match_dir_failure(request, testdir, basic_case_dir):
         "*     },",
         "* }, 'dict_snapshot1')",
         'E* A*Error: value does not match the expected value in snapshot case_dir?dict_snapshot1?subdir1?subobj1.txt',
+        'E*   (run pytest with --snapshot-update to update snapshots)',
         "E* assert * == *",
         "E* - the value of subobj1.txt",
         "E* + the INCORRECT value of subobj1.txt",
@@ -88,9 +89,9 @@ def test_assert_match_dir_missing_snapshot(testdir, basic_case_dir):
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
         "E* AssertionError: Values do not match snapshots in case_dir?dict_snapshot1",
+        'E*   (run pytest with --snapshot-update to update the snapshot directory)',
         'E*   Values without snapshots:',
         'E*     subdir1?new_obj.txt',
-        'E*   Run pytest with --snapshot-update to update the snapshot directory.',
     ])
     assert result.ret == 1
 
@@ -108,9 +109,9 @@ def test_assert_match_dir_missing_value(testdir, basic_case_dir):
     result.stdout.fnmatch_lines([
         '*::test_sth FAILED*',
         "E* AssertionError: Values do not match snapshots in case_dir?dict_snapshot1",
+        'E*   (run pytest with --snapshot-update to update the snapshot directory)',
         'E*   Snapshots without values:',
         'E*     subdir1?subobj1.txt',
-        'E*   Run pytest with --snapshot-update to update the snapshot directory.',
     ])
     assert result.ret == 1
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -15,7 +15,7 @@ def test_help_message(testdir):
     result = testdir.runpytest('--help')
     result.stdout.fnmatch_lines([
         'snapshot:',
-        '*--snapshot-update*Update snapshots.',
+        '*--snapshot-update*Update snapshot files instead of testing against them.',
     ])
 
 


### PR DESCRIPTION
Developers entering a codebase that uses pytest-snapshot might not know what to do if they break a snapshot test. This commit improves error messages by adding suggested next steps to resolve the issue.

This PR fixes issue #53.