### PR TITLE
Write dump file on failed test

### DIFF
--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -196,6 +196,7 @@ class Snapshot:
                     snapshot_diff_msg = 'value does not match the expected value in snapshot {}\n' \
                                         '  (run pytest with --snapshot-update to update snapshots)\n{}'.format(
                                             shorten_path(snapshot_path), snapshot_diff_msg)
+                    snapshot_path.with_suffix('.dump' + snapshot_path.suffix).write_bytes(encode(value))
                     raise AssertionError(snapshot_diff_msg)
             else:
                 raise AssertionError(


### PR DESCRIPTION
Hi,

This tool is really remarkably good!  As in issue #54, I needed some kind of dump file to make data visualization comparisons in diff tools simpler on failed snapshot tests; this pull request just demonstrates a small change I made on my local installation that made the workflow very nice:

  1. Run the tests: `pytest`
  2. Use a diff tool to investigate failed tests (currently I just use PyCharm's diff tool, and compare the original file (e.g. myplot.png) with the observed file (e.g. myplot.dump.png), which has the same ending file extension to make it easier on diff tools.
  3. If approving, then update the snapshot with deletion to delete the dump files: `pytest --snapshot-update --allow-snapshot-deletion`

A caveat is file cleanup; I only found that the `snapshot.assert_match_dir()` function worked with `--allow-snapshot-deletion`, so a better implementation might be to do extra file deletion also on `assert_match()`.  But using `asset_match_dir()` for now has been fine.

Anyway, I'm sure there is a better way to do this; I hope you'll consider including dump files as a feature for this really great tool!

Best wishes,

Nick