### PR TITLE
Support static type checking

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,10 +35,6 @@ jobs:
             os: macos-latest
             # macos builds sometimes get stuck starting "python -m tox".
             experimental: true
-          - python-version: 3.5
-            # Latest os version that supports Python 3.5
-            os: ubuntu-20.04
-            experimental: false
           - python-version: 3.6
             # Latest os version that supports Python 3.6
             os: ubuntu-20.04

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.rst
+include pytest_snapshot/py.typed
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/pytest_snapshot/_utils.py
+++ b/pytest_snapshot/_utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 from pathlib import Path
+from typing import List, Tuple
 
 import pytest
 
@@ -44,7 +45,7 @@ def might_be_valid_filename(s: str) -> bool:
     )
 
 
-def simple_version_parse(version: str):
+def simple_version_parse(version: str) -> Tuple[int, int, int]:
     """
     Returns a 3 tuple of the versions major, minor, and patch.
     Raises a value error if the version string is unsupported.
@@ -75,7 +76,7 @@ def _pytest_expected_on_right() -> bool:
         return pytest_version >= (5, 4, 0)
 
 
-def flatten_dict(d: dict):
+def flatten_dict(d: dict) -> List[Tuple[List, ...]]:
     """
     Returns the flattened dict representation of the given dict.
 
@@ -96,7 +97,7 @@ def flatten_dict(d: dict):
     return result
 
 
-def _flatten_dict(obj, result, prefix):
+def _flatten_dict(obj: dict, result: list, prefix: list) -> None:
     if type(obj) is dict:
         for k, v in obj.items():
             prefix.append(k)
@@ -106,7 +107,7 @@ def _flatten_dict(obj, result, prefix):
         result.append((list(prefix), obj))
 
 
-def flatten_filesystem_dict(d):
+def flatten_filesystem_dict(d: dict) -> dict:
     """
     Returns the flattened dict of a nested dictionary structure describing a filesystem.
 

--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -2,7 +2,7 @@ import operator
 import os
 import re
 from pathlib import Path
-from typing import List, Union
+from typing import Any, Callable, List, Tuple, Union
 
 import pytest
 import _pytest.python
@@ -36,7 +36,7 @@ def snapshot(request):
         yield snapshot
 
 
-def _assert_equal(value, snapshot) -> None:
+def _assert_equal(value: Any, snapshot: Any) -> None:
     if _pytest_expected_on_right():
         assert value == snapshot
     else:
@@ -135,7 +135,9 @@ class Snapshot:
 
         return snapshot_path
 
-    def _get_compare_encode_decode(self, value: Union[str, bytes]):
+    def _get_compare_encode_decode(self, value: Union[str, bytes]) -> Tuple[
+        Callable[[Any, Any], None], Callable[..., bytes], Callable[..., str]
+    ]:
         """
         Returns a 3-tuple of a compare function, an encoding function, and a decoding function.
 
@@ -151,7 +153,7 @@ class Snapshot:
         else:
             raise TypeError('value must be str or bytes')
 
-    def assert_match(self, value: Union[str, bytes], snapshot_name: Union[str, Path]):
+    def assert_match(self, value: Union[str, bytes], snapshot_name: Union[str, Path]) -> None:
         """
         Asserts that ``value`` equals the current value of the snapshot with the given ``snapshot_name``.
 
@@ -202,7 +204,7 @@ class Snapshot:
                     "snapshot {} doesn't exist. (run pytest with --snapshot-update to create it)".format(
                         shorten_path(snapshot_path)))
 
-    def assert_match_dir(self, dir_dict: dict, snapshot_dir_name: Union[str, Path]):
+    def assert_match_dir(self, dir_dict: dict, snapshot_dir_name: Union[str, Path]) -> None:
         """
         Asserts that the values in dir_dict equal the current values in the given snapshot directory.
 

--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -14,7 +14,7 @@ from pytest_snapshot._utils import flatten_filesystem_dict, _RecursiveDict
 PARAMETRIZED_TEST_REGEX = re.compile(r'^.*?\[(.*)]$')
 
 
-def pytest_addoption(parser: _pytest.config.argparsing.Parser):
+def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
     group = parser.getgroup('snapshot')
     group.addoption(
         '--snapshot-update',
@@ -87,10 +87,10 @@ class Snapshot:
         self._updated_snapshots = []
         self._snapshots_to_delete = []
 
-    def __enter__(self):
+    def __enter__(self) -> "Snapshot":
         return self
 
-    def __exit__(self, *_: Any):
+    def __exit__(self, *_: Any) -> None:
         if self._created_snapshots or self._updated_snapshots or self._snapshots_to_delete:
             message_lines = ['Snapshot directory was modified: {}'.format(shorten_path(self.snapshot_dir)),
                              '  (verify that the changes are expected before committing them to version control)']
@@ -116,11 +116,11 @@ class Snapshot:
             pytest.fail('\n'.join(message_lines), pytrace=False)
 
     @property
-    def snapshot_dir(self):
+    def snapshot_dir(self) -> Path:
         return self._snapshot_dir
 
     @snapshot_dir.setter
-    def snapshot_dir(self, value):
+    def snapshot_dir(self, value: Union[str, os.PathLike[str], Path]) -> None:
         self._snapshot_dir = Path(value).absolute()
 
     def _snapshot_path(self, snapshot_name: Union[str, os.PathLike[str]]) -> Path:

--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -128,10 +128,10 @@ class Snapshot:
         return self._snapshot_dir
 
     @snapshot_dir.setter
-    def snapshot_dir(self, value: Union[str, os.PathLike[str]]) -> None:
+    def snapshot_dir(self, value: Union[str, 'os.PathLike[str]']) -> None:
         self._snapshot_dir = Path(value).absolute()
 
-    def _snapshot_path(self, snapshot_name: Union[str, os.PathLike[str]]) -> Path:
+    def _snapshot_path(self, snapshot_name: Union[str, 'os.PathLike[str]']) -> Path:
         """
         Returns the absolute path to the given snapshot.
         """
@@ -168,7 +168,7 @@ class Snapshot:
         else:
             raise TypeError('value must be str or bytes')
 
-    def assert_match(self, value: AnyStr, snapshot_name: Union[str, os.PathLike[str]]) -> None:
+    def assert_match(self, value: AnyStr, snapshot_name: Union[str, 'os.PathLike[str]']) -> None:
         """
         Asserts that ``value`` equals the current value of the snapshot with the given ``snapshot_name``.
 
@@ -223,7 +223,7 @@ class Snapshot:
     def assert_match_dir(
         self,
         dir_dict: _RecursiveDict[str, Union[bytes, str]],
-        snapshot_dir_name: Union[str, os.PathLike[str]]
+        snapshot_dir_name: Union[str, 'os.PathLike[str]']
     ) -> None:
         """
         Asserts that the values in dir_dict equal the current values in the given snapshot directory.

--- a/pytest_snapshot/plugin.py
+++ b/pytest_snapshot/plugin.py
@@ -68,12 +68,12 @@ def _file_decode(data: bytes) -> str:
 
 
 class Snapshot:
-    _snapshot_update = None  # type: bool
-    _allow_snapshot_deletion = None  # type: bool
-    _created_snapshots = None  # type: List[Path]
-    _updated_snapshots = None  # type: List[Path]
-    _snapshots_to_delete = None  # type: List[Path]
-    _snapshot_dir = None  # type: Path
+    _snapshot_update: bool
+    _allow_snapshot_deletion: bool
+    _created_snapshots: List[Path]
+    _updated_snapshots: List[Path]
+    _snapshots_to_delete: List[Path]
+    _snapshot_dir: Path
 
     def __init__(self, snapshot_update: bool, allow_snapshot_deletion: bool, snapshot_dir: Path):
         self._snapshot_update = snapshot_update

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ classifiers =
 
 [options]
 packages = pytest_snapshot
+zip_safe = False
+include_package_data = True
 python_requires = >=3.5
 install_requires =
     pytest >= 3.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 envlist =
     # Pytest <6.2.5 not supported on Python >=3.10
     py{36,37,38,39}-pytest{3,4,5}-coverage
-    py{35,36,37,38,39,310,311,312,3}-pytest{6,}-coverage
+    py{36,37,38,39,310,311,312,3}-pytest{6,}-coverage
     # Coverage is slow in pypy
     pypy3-pytest{6,}
     flake8
@@ -49,7 +49,6 @@ max-line-length = 120
 
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
     # Coverage is slow in pypy
     pypy3-pytest{3,4,5,6,}
     flake8
+    pyright
+    mypy
 
 [testenv]
 deps =
@@ -33,6 +35,17 @@ skip_install = true
 deps = flake8
 commands = flake8 pytest_snapshot setup.py tests
 
+[testenv:pyright]
+deps = pyright
+usedevelop = false
+commands = pyright --verifytypes pytest_snapshot --ignoreexternal
+
+[testenv:mypy]
+deps =
+    mypy
+    py
+commands = mypy -p pytest_snapshot
+
 [flake8]
 max-line-length = 120
 
@@ -43,6 +56,6 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310, flake8
+    3.10: py310, flake8, mypy, pyright
     3: py3
     pypy-3: pypy3


### PR DESCRIPTION
This pull request improves type annotations in the package, making it [PEP 561](https://peps.python.org/pep-0561/#packaging-type-information)-compatible.

In details:

- Adds `py.typed` marker.
- Adds `mypy` and `pyright` tox environments to ensure full compatibility with those tools.
- Removes old-style type comments.
- Adds type annotations to all publicly exposed methods.
- Adds type annotations to internal utility methods.

Thanks to @mjpieters for contributing some of the code and ideas.


_If you're unfamiliar with mypy, check these materials:
https://dev.to/whtsky/don-t-forget-py-typed-for-your-typed-python-package-2aa3
https://mypy.readthedocs.io/en/latest/installed_packages.html#creating-pep-561-compatible-packages_